### PR TITLE
Added support for passing in `replace-in-file` functions

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -9,7 +9,7 @@
     "rules": {
       "eslint-comments/no-use": "off",
       "import/no-namespace": "off",
-      "no-unused-vars": "error",
+      "no-unused-vars": "off",
       "@typescript-eslint/no-unused-vars": "error",
       "@typescript-eslint/explicit-member-accessibility": ["error", {"accessibility": "no-public"}],
       "@typescript-eslint/array-type": "error",

--- a/__tests__/prepare.test.ts
+++ b/__tests__/prepare.test.ts
@@ -171,3 +171,23 @@ test("replacements are global", async () => {
 
   // Will throw if results do not match
 });
+
+test("prepare should replace using function", async () => {
+  const replacements = [
+    {
+      files: [path.join(d.name, "/*.py")],
+      from: '__VERSION__ = ".*"',
+      to: (match) => `__VERSION__ = 2`,
+    },
+    {
+      files: [path.join(d.name, "/build.gradle")],
+      from: "version = '.*'",
+      to: (match) => "version = 2",
+    },
+  ];
+
+  await prepare({ replacements }, context);
+
+  await assertFileContentsContain("__init__.py", `__VERSION__ = 2`);
+  await assertFileContents("build.gradle", "version = 2");
+});

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -36,8 +36,16 @@ export interface Replacement {
      *
      * The context object is used to render the template. Additional values
      * can be found at: https://semantic-release.gitbook.io/semantic-release/developer-guide/js-api#result
+     *
+     * For advacned replacement, pass in a function to replace non-standard variables
+     * ```
+     * {
+     *    from: `__VERSION__ = 11`, // eslint-disable-line
+     *    to: (matched) => `__VERSION: ${parseInt(matched.split('=')[1].trim()) + 1}`, // eslint-disable-line
+     *  },
+     * ```
      */
-    to: string;
+    to: string | ((a: string) => string);
     ignore?: string[];
     allowEmptyPaths?: boolean;
     countMatches?: boolean;

--- a/dist/index.js
+++ b/dist/index.js
@@ -65,8 +65,9 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 exports.__esModule = true;
+exports.prepare = void 0;
+var replace_in_file_1 = require("replace-in-file");
 var lodash_1 = require("lodash");
-var replace_in_file_1 = __importDefault(require("replace-in-file"));
 var jest_diff_1 = __importDefault(require("jest-diff"));
 function prepare(PluginConfig, context) {
     return __awaiter(this, void 0, void 0, function () {
@@ -82,16 +83,19 @@ function prepare(PluginConfig, context) {
                     results = replacement.results;
                     delete replacement.results;
                     replaceInFileConfig = replacement;
-                    replaceInFileConfig.to = lodash_1.template(replacement.to)(__assign({}, context));
-                    replaceInFileConfig.from = new RegExp(replacement.from, "g");
-                    return [4 /*yield*/, replace_in_file_1["default"](replaceInFileConfig)];
+                    replaceInFileConfig.to =
+                        typeof replacement.to === "function"
+                            ? replacement.to
+                            : lodash_1.template(replacement.to)(__assign({}, context));
+                    replaceInFileConfig.from = new RegExp(replacement.from, "gm");
+                    return [4 /*yield*/, replace_in_file_1.replaceInFile(replaceInFileConfig)];
                 case 2:
                     actual = _b.sent();
                     if (results) {
                         results = results.sort();
                         actual = actual.sort();
                         if (!lodash_1.isEqual(actual.sort(), results.sort())) {
-                            throw new Error("Results differed from actual! \n" + jest_diff_1["default"](results, actual));
+                            throw new Error("Expected match not found!\n" + jest_diff_1["default"](actual, results));
                         }
                     }
                     _b.label = 3;

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,6 @@
-[@google/semantic-release-replace-plugin](README.md)
+**[@google/semantic-release-replace-plugin](README.md)**
+
+> Globals
 
 # @google/semantic-release-replace-plugin
 

--- a/docs/interfaces/_index_.pluginconfig.md
+++ b/docs/interfaces/_index_.pluginconfig.md
@@ -46,6 +46,6 @@ PluginConfig is used to provide multiple replacement.
 
 •  **replacements**: [Replacement](_index_.replacement.md)[]
 
-*Defined in [index.ts:93](https://github.com/Borduhh/semantic-release-replace-plugin/blob/d2e8b02/src/index.ts#L93)*
+*Defined in [index.ts:101](https://github.com/Borduhh/semantic-release-replace-plugin/blob/6dd4918/src/index.ts#L101)*
 
 An array of replacements to be made.

--- a/docs/interfaces/_index_.pluginconfig.md
+++ b/docs/interfaces/_index_.pluginconfig.md
@@ -1,4 +1,6 @@
-[@google/semantic-release-replace-plugin](../README.md) › ["index"](../modules/_index_.md) › [PluginConfig](_index_.pluginconfig.md)
+**[@google/semantic-release-replace-plugin](../README.md)**
+
+> [Globals](../README.md) / ["index"](../modules/_index_.md) / PluginConfig
 
 # Interface: PluginConfig
 
@@ -40,10 +42,10 @@ PluginConfig is used to provide multiple replacement.
 
 ## Properties
 
-###  replacements
+### replacements
 
-• **replacements**: *[Replacement](_index_.replacement.md)[]*
+•  **replacements**: [Replacement](_index_.replacement.md)[]
 
-*Defined in [index.ts:93](https://github.com/google/semantic-release-replace-plugin/blob/master/src/index.ts#L93)*
+*Defined in [index.ts:93](https://github.com/Borduhh/semantic-release-replace-plugin/blob/d2e8b02/src/index.ts#L93)*
 
 An array of replacements to be made.

--- a/docs/interfaces/_index_.pluginconfig.md
+++ b/docs/interfaces/_index_.pluginconfig.md
@@ -46,6 +46,6 @@ PluginConfig is used to provide multiple replacement.
 
 •  **replacements**: [Replacement](_index_.replacement.md)[]
 
-*Defined in [index.ts:101](https://github.com/Borduhh/semantic-release-replace-plugin/blob/6dd4918/src/index.ts#L101)*
+*Defined in [index.ts:101](https://github.com/google/semantic-release-replace-plugin/blob/master/src/index.ts#L101)*
 
 An array of replacements to be made.

--- a/docs/interfaces/_index_.replacement.md
+++ b/docs/interfaces/_index_.replacement.md
@@ -32,7 +32,7 @@ with the difference being the single string for `to` and `from`.
 
 • `Optional` **allowEmptyPaths**: boolean
 
-*Defined in [index.ts:48](https://github.com/Borduhh/semantic-release-replace-plugin/blob/d2e8b02/src/index.ts#L48)*
+*Defined in [index.ts:56](https://github.com/Borduhh/semantic-release-replace-plugin/blob/6dd4918/src/index.ts#L56)*
 
 ___
 
@@ -40,7 +40,7 @@ ___
 
 • `Optional` **countMatches**: boolean
 
-*Defined in [index.ts:49](https://github.com/Borduhh/semantic-release-replace-plugin/blob/d2e8b02/src/index.ts#L49)*
+*Defined in [index.ts:57](https://github.com/Borduhh/semantic-release-replace-plugin/blob/6dd4918/src/index.ts#L57)*
 
 ___
 
@@ -48,7 +48,7 @@ ___
 
 • `Optional` **disableGlobs**: boolean
 
-*Defined in [index.ts:50](https://github.com/Borduhh/semantic-release-replace-plugin/blob/d2e8b02/src/index.ts#L50)*
+*Defined in [index.ts:58](https://github.com/Borduhh/semantic-release-replace-plugin/blob/6dd4918/src/index.ts#L58)*
 
 ___
 
@@ -56,7 +56,7 @@ ___
 
 • `Optional` **dry**: boolean
 
-*Defined in [index.ts:52](https://github.com/Borduhh/semantic-release-replace-plugin/blob/d2e8b02/src/index.ts#L52)*
+*Defined in [index.ts:60](https://github.com/Borduhh/semantic-release-replace-plugin/blob/6dd4918/src/index.ts#L60)*
 
 ___
 
@@ -64,7 +64,7 @@ ___
 
 • `Optional` **encoding**: string
 
-*Defined in [index.ts:51](https://github.com/Borduhh/semantic-release-replace-plugin/blob/d2e8b02/src/index.ts#L51)*
+*Defined in [index.ts:59](https://github.com/Borduhh/semantic-release-replace-plugin/blob/6dd4918/src/index.ts#L59)*
 
 ___
 
@@ -72,7 +72,7 @@ ___
 
 •  **files**: string[]
 
-*Defined in [index.ts:31](https://github.com/Borduhh/semantic-release-replace-plugin/blob/d2e8b02/src/index.ts#L31)*
+*Defined in [index.ts:31](https://github.com/Borduhh/semantic-release-replace-plugin/blob/6dd4918/src/index.ts#L31)*
 
 files to search for replacements
 
@@ -82,7 +82,7 @@ ___
 
 •  **from**: string
 
-*Defined in [index.ts:37](https://github.com/Borduhh/semantic-release-replace-plugin/blob/d2e8b02/src/index.ts#L37)*
+*Defined in [index.ts:37](https://github.com/Borduhh/semantic-release-replace-plugin/blob/6dd4918/src/index.ts#L37)*
 
 The RegExp pattern to use to match.
 
@@ -94,7 +94,7 @@ ___
 
 • `Optional` **ignore**: string[]
 
-*Defined in [index.ts:47](https://github.com/Borduhh/semantic-release-replace-plugin/blob/d2e8b02/src/index.ts#L47)*
+*Defined in [index.ts:55](https://github.com/Borduhh/semantic-release-replace-plugin/blob/6dd4918/src/index.ts#L55)*
 
 ___
 
@@ -102,7 +102,7 @@ ___
 
 • `Optional` **results**: { file: string ; hasChanged: boolean ; numMatches?: number ; numReplacements?: number  }[]
 
-*Defined in [index.ts:57](https://github.com/Borduhh/semantic-release-replace-plugin/blob/d2e8b02/src/index.ts#L57)*
+*Defined in [index.ts:65](https://github.com/Borduhh/semantic-release-replace-plugin/blob/6dd4918/src/index.ts#L65)*
 
 The results array can be passed to ensure that the expected replacements
 have been made, and if not, throw and exception with the diff.
@@ -111,9 +111,9 @@ ___
 
 ### to
 
-•  **to**: string
+•  **to**: string \| (a: string) => string
 
-*Defined in [index.ts:46](https://github.com/Borduhh/semantic-release-replace-plugin/blob/d2e8b02/src/index.ts#L46)*
+*Defined in [index.ts:54](https://github.com/Borduhh/semantic-release-replace-plugin/blob/6dd4918/src/index.ts#L54)*
 
 The replacement value using a template of variables.
 
@@ -121,3 +121,11 @@ The replacement value using a template of variables.
 
 The context object is used to render the template. Additional values
 can be found at: https://semantic-release.gitbook.io/semantic-release/developer-guide/js-api#result
+
+For advacned replacement, pass in a function to replace non-standard variables
+```
+{
+   from: `__VERSION__ = 11`, // eslint-disable-line
+   to: (matched) => `__VERSION: ${parseInt(matched.split('=')[1].trim()) + 1}`, // eslint-disable-line
+ },
+```

--- a/docs/interfaces/_index_.replacement.md
+++ b/docs/interfaces/_index_.replacement.md
@@ -1,4 +1,6 @@
-[@google/semantic-release-replace-plugin](../README.md) › ["index"](../modules/_index_.md) › [Replacement](_index_.replacement.md)
+**[@google/semantic-release-replace-plugin](../README.md)**
+
+> [Globals](../README.md) / ["index"](../modules/_index_.md) / Replacement
 
 # Interface: Replacement
 
@@ -13,74 +15,74 @@ with the difference being the single string for `to` and `from`.
 
 ### Properties
 
-* [allowEmptyPaths](_index_.replacement.md#optional-allowemptypaths)
-* [countMatches](_index_.replacement.md#optional-countmatches)
-* [disableGlobs](_index_.replacement.md#optional-disableglobs)
-* [dry](_index_.replacement.md#optional-dry)
-* [encoding](_index_.replacement.md#optional-encoding)
+* [allowEmptyPaths](_index_.replacement.md#allowemptypaths)
+* [countMatches](_index_.replacement.md#countmatches)
+* [disableGlobs](_index_.replacement.md#disableglobs)
+* [dry](_index_.replacement.md#dry)
+* [encoding](_index_.replacement.md#encoding)
 * [files](_index_.replacement.md#files)
 * [from](_index_.replacement.md#from)
-* [ignore](_index_.replacement.md#optional-ignore)
-* [results](_index_.replacement.md#optional-results)
+* [ignore](_index_.replacement.md#ignore)
+* [results](_index_.replacement.md#results)
 * [to](_index_.replacement.md#to)
 
 ## Properties
 
-### `Optional` allowEmptyPaths
+### allowEmptyPaths
 
-• **allowEmptyPaths**? : *boolean*
+• `Optional` **allowEmptyPaths**: boolean
 
-*Defined in [index.ts:48](https://github.com/google/semantic-release-replace-plugin/blob/master/src/index.ts#L48)*
-
-___
-
-### `Optional` countMatches
-
-• **countMatches**? : *boolean*
-
-*Defined in [index.ts:49](https://github.com/google/semantic-release-replace-plugin/blob/master/src/index.ts#L49)*
+*Defined in [index.ts:48](https://github.com/Borduhh/semantic-release-replace-plugin/blob/d2e8b02/src/index.ts#L48)*
 
 ___
 
-### `Optional` disableGlobs
+### countMatches
 
-• **disableGlobs**? : *boolean*
+• `Optional` **countMatches**: boolean
 
-*Defined in [index.ts:50](https://github.com/google/semantic-release-replace-plugin/blob/master/src/index.ts#L50)*
-
-___
-
-### `Optional` dry
-
-• **dry**? : *boolean*
-
-*Defined in [index.ts:52](https://github.com/google/semantic-release-replace-plugin/blob/master/src/index.ts#L52)*
+*Defined in [index.ts:49](https://github.com/Borduhh/semantic-release-replace-plugin/blob/d2e8b02/src/index.ts#L49)*
 
 ___
 
-### `Optional` encoding
+### disableGlobs
 
-• **encoding**? : *string*
+• `Optional` **disableGlobs**: boolean
 
-*Defined in [index.ts:51](https://github.com/google/semantic-release-replace-plugin/blob/master/src/index.ts#L51)*
+*Defined in [index.ts:50](https://github.com/Borduhh/semantic-release-replace-plugin/blob/d2e8b02/src/index.ts#L50)*
 
 ___
 
-###  files
+### dry
 
-• **files**: *string[]*
+• `Optional` **dry**: boolean
 
-*Defined in [index.ts:31](https://github.com/google/semantic-release-replace-plugin/blob/master/src/index.ts#L31)*
+*Defined in [index.ts:52](https://github.com/Borduhh/semantic-release-replace-plugin/blob/d2e8b02/src/index.ts#L52)*
+
+___
+
+### encoding
+
+• `Optional` **encoding**: string
+
+*Defined in [index.ts:51](https://github.com/Borduhh/semantic-release-replace-plugin/blob/d2e8b02/src/index.ts#L51)*
+
+___
+
+### files
+
+•  **files**: string[]
+
+*Defined in [index.ts:31](https://github.com/Borduhh/semantic-release-replace-plugin/blob/d2e8b02/src/index.ts#L31)*
 
 files to search for replacements
 
 ___
 
-###  from
+### from
 
-• **from**: *string*
+•  **from**: string
 
-*Defined in [index.ts:37](https://github.com/google/semantic-release-replace-plugin/blob/master/src/index.ts#L37)*
+*Defined in [index.ts:37](https://github.com/Borduhh/semantic-release-replace-plugin/blob/d2e8b02/src/index.ts#L37)*
 
 The RegExp pattern to use to match.
 
@@ -88,30 +90,30 @@ Uses `String.replace(new RegExp(s, 'g'), to)` for implementation.
 
 ___
 
-### `Optional` ignore
+### ignore
 
-• **ignore**? : *string[]*
+• `Optional` **ignore**: string[]
 
-*Defined in [index.ts:47](https://github.com/google/semantic-release-replace-plugin/blob/master/src/index.ts#L47)*
+*Defined in [index.ts:47](https://github.com/Borduhh/semantic-release-replace-plugin/blob/d2e8b02/src/index.ts#L47)*
 
 ___
 
-### `Optional` results
+### results
 
-• **results**? : *object[]*
+• `Optional` **results**: { file: string ; hasChanged: boolean ; numMatches?: number ; numReplacements?: number  }[]
 
-*Defined in [index.ts:57](https://github.com/google/semantic-release-replace-plugin/blob/master/src/index.ts#L57)*
+*Defined in [index.ts:57](https://github.com/Borduhh/semantic-release-replace-plugin/blob/d2e8b02/src/index.ts#L57)*
 
 The results array can be passed to ensure that the expected replacements
 have been made, and if not, throw and exception with the diff.
 
 ___
 
-###  to
+### to
 
-• **to**: *string*
+•  **to**: string
 
-*Defined in [index.ts:46](https://github.com/google/semantic-release-replace-plugin/blob/master/src/index.ts#L46)*
+*Defined in [index.ts:46](https://github.com/Borduhh/semantic-release-replace-plugin/blob/d2e8b02/src/index.ts#L46)*
 
 The replacement value using a template of variables.
 

--- a/docs/modules/_index_.md
+++ b/docs/modules/_index_.md
@@ -1,4 +1,6 @@
-[@google/semantic-release-replace-plugin](../README.md) › ["index"](_index_.md)
+**[@google/semantic-release-replace-plugin](../README.md)**
+
+> [Globals](../README.md) / "index"
 
 # Module: "index"
 
@@ -15,17 +17,17 @@
 
 ## Functions
 
-###  prepare
+### prepare
 
-▸ **prepare**(`PluginConfig`: [PluginConfig](../interfaces/_index_.pluginconfig.md), `context`: Context): *Promise‹void›*
+▸ **prepare**(`PluginConfig`: [PluginConfig](../interfaces/_index_.pluginconfig.md), `context`: Context): Promise<void\>
 
-*Defined in [index.ts:96](https://github.com/google/semantic-release-replace-plugin/blob/master/src/index.ts#L96)*
+*Defined in [index.ts:96](https://github.com/Borduhh/semantic-release-replace-plugin/blob/d2e8b02/src/index.ts#L96)*
 
-**Parameters:**
+#### Parameters:
 
 Name | Type |
 ------ | ------ |
 `PluginConfig` | [PluginConfig](../interfaces/_index_.pluginconfig.md) |
 `context` | Context |
 
-**Returns:** *Promise‹void›*
+**Returns:** Promise<void\>

--- a/docs/modules/_index_.md
+++ b/docs/modules/_index_.md
@@ -21,7 +21,7 @@
 
 ▸ **prepare**(`PluginConfig`: [PluginConfig](../interfaces/_index_.pluginconfig.md), `context`: Context): Promise<void\>
 
-*Defined in [index.ts:96](https://github.com/Borduhh/semantic-release-replace-plugin/blob/d2e8b02/src/index.ts#L96)*
+*Defined in [index.ts:104](https://github.com/Borduhh/semantic-release-replace-plugin/blob/6dd4918/src/index.ts#L104)*
 
 #### Parameters:
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -104,7 +104,10 @@ export async function prepare(
 
     const replaceInFileConfig = replacement as ReplaceInFileConfig;
 
-    replaceInFileConfig.to = template(replacement.to)({ ...context });
+    replaceInFileConfig.to =
+      typeof replacement.to === "function"
+        ? replacement.to
+        : template(replacement.to)({ ...context });
     replaceInFileConfig.from = new RegExp(replacement.from, "gm");
 
     let actual = await replaceInFile(replaceInFileConfig);

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,8 +42,16 @@ export interface Replacement {
    *
    * The context object is used to render the template. Additional values
    * can be found at: https://semantic-release.gitbook.io/semantic-release/developer-guide/js-api#result
+   *
+   * For advacned replacement, pass in a function to replace non-standard variables
+   * ```
+   * {
+   *    from: `__VERSION__ = 11`, // eslint-disable-line
+   *    to: (matched) => `__VERSION: ${parseInt(matched.split('=')[1].trim()) + 1}`, // eslint-disable-line
+   *  },
+   * ```
    */
-  to: string;
+  to: string | ((a: string) => string);
   ignore?: string[];
   allowEmptyPaths?: boolean;
   countMatches?: boolean;

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,7 +43,7 @@ export interface Replacement {
    * The context object is used to render the template. Additional values
    * can be found at: https://semantic-release.gitbook.io/semantic-release/developer-guide/js-api#result
    *
-   * For advanced replacement, pass in a function to replace non-standard variables
+   * For advanced replacement (NOTE: only for use with `release.config.js` file version), pass in a function to replace non-standard variables
    * ```
    * {
    *    from: `__VERSION__ = 11`, // eslint-disable-line

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-import { ReplaceInFileConfig, replaceInFile } from "replace-in-file";
-import { isEqual, template } from "lodash";
+import { ReplaceInFileConfig, replaceInFile } from 'replace-in-file';
+import { isEqual, template } from 'lodash';
 
-import { Context } from "semantic-release";
-import diffDefault from "jest-diff";
+import { Context } from 'semantic-release';
+import diffDefault from 'jest-diff';
 
 /**
  * Replacement is simlar to the interface used by https://www.npmjs.com/package/replace-in-file
@@ -43,7 +43,7 @@ export interface Replacement {
    * The context object is used to render the template. Additional values
    * can be found at: https://semantic-release.gitbook.io/semantic-release/developer-guide/js-api#result
    *
-   * For advacned replacement, pass in a function to replace non-standard variables
+   * For advanced replacement, pass in a function to replace non-standard variables
    * ```
    * {
    *    from: `__VERSION__ = 11`, // eslint-disable-line
@@ -101,10 +101,7 @@ export interface PluginConfig {
   replacements: Replacement[];
 }
 
-export async function prepare(
-  PluginConfig: PluginConfig,
-  context: Context
-): Promise<void> {
+export async function prepare(PluginConfig: PluginConfig, context: Context): Promise<void> {
   for (const replacement of PluginConfig.replacements) {
     let { results } = replacement;
 
@@ -113,10 +110,10 @@ export async function prepare(
     const replaceInFileConfig = replacement as ReplaceInFileConfig;
 
     replaceInFileConfig.to =
-      typeof replacement.to === "function"
+      typeof replacement.to === 'function'
         ? replacement.to
         : template(replacement.to)({ ...context });
-    replaceInFileConfig.from = new RegExp(replacement.from, "gm");
+    replaceInFileConfig.from = new RegExp(replacement.from, 'gm');
 
     let actual = await replaceInFile(replaceInFileConfig);
 
@@ -125,9 +122,7 @@ export async function prepare(
       actual = actual.sort();
 
       if (!isEqual(actual.sort(), results.sort())) {
-        throw new Error(
-          `Expected match not found!\n${diffDefault(actual, results)}`
-        );
+        throw new Error(`Expected match not found!\n${diffDefault(actual, results)}`);
       }
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-import { ReplaceInFileConfig, replaceInFile } from 'replace-in-file';
-import { isEqual, template } from 'lodash';
+import { ReplaceInFileConfig, replaceInFile } from "replace-in-file";
+import { isEqual, template } from "lodash";
 
-import { Context } from 'semantic-release';
-import diffDefault from 'jest-diff';
+import { Context } from "semantic-release";
+import diffDefault from "jest-diff";
 
 /**
  * Replacement is simlar to the interface used by https://www.npmjs.com/package/replace-in-file
@@ -101,7 +101,10 @@ export interface PluginConfig {
   replacements: Replacement[];
 }
 
-export async function prepare(PluginConfig: PluginConfig, context: Context): Promise<void> {
+export async function prepare(
+  PluginConfig: PluginConfig,
+  context: Context
+): Promise<void> {
   for (const replacement of PluginConfig.replacements) {
     let { results } = replacement;
 
@@ -110,10 +113,10 @@ export async function prepare(PluginConfig: PluginConfig, context: Context): Pro
     const replaceInFileConfig = replacement as ReplaceInFileConfig;
 
     replaceInFileConfig.to =
-      typeof replacement.to === 'function'
+      typeof replacement.to === "function"
         ? replacement.to
         : template(replacement.to)({ ...context });
-    replaceInFileConfig.from = new RegExp(replacement.from, 'gm');
+    replaceInFileConfig.from = new RegExp(replacement.from, "gm");
 
     let actual = await replaceInFile(replaceInFileConfig);
 
@@ -122,7 +125,9 @@ export async function prepare(PluginConfig: PluginConfig, context: Context): Pro
       actual = actual.sort();
 
       if (!isEqual(actual.sort(), results.sort())) {
-        throw new Error(`Expected match not found!\n${diffDefault(actual, results)}`);
+        throw new Error(
+          `Expected match not found!\n${diffDefault(actual, results)}`
+        );
       }
     }
   }


### PR DESCRIPTION
Added the ability to pass in a function as supported by `replace-in-file`(https://github.com/adamreisnz/replace-in-file#using-callbacks-for-to).

This is helpful when you are updating versioning for non-standard release channels like Android (what we are using it for).
```
 {
    files: ['app.config.js'],
    from: 'versionCode: .*',
    to: (match) => `versionCode: ${parseInt(match.split(':')[1].trim()) + 1}`,
 },
````

closes #45