### PR TITLE
feat: context available in replacement function

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -114,7 +114,7 @@ export async function prepare(
 
     replaceInFileConfig.to =
       typeof replacement.to === "function"
-        ? replacement.to
+        ? replacement.to.bind(context)
         : template(replacement.to)({ ...context });
     replaceInFileConfig.from = new RegExp(replacement.from, "gm");
 


### PR DESCRIPTION
Make `context` available in replacement function by binding the function's execution environment to the `semantic-release` context.