### PR TITLE
feat: support more replace-in-file functionality

### DIFF
--- a/__tests__/prepare.test.ts
+++ b/__tests__/prepare.test.ts
@@ -55,7 +55,7 @@ async function assertFileContents(name: string, expected: string) {
 
 async function assertFileContentsContain(name: string, expected: string) {
   const actual = await fs.readFileSync(path.join(d.name, name), "utf-8");
-  expect.stringContaining(expected);
+  expect(actual).toEqual(expect.stringContaining(expected));
 }
 
 test("prepare should replace using regex", async () => {

--- a/__tests__/prepare.test.ts
+++ b/__tests__/prepare.test.ts
@@ -269,3 +269,26 @@ test("prepare passes the `context` as the final function argument to `from` call
   await assertFileContentsContain("foo.md", "npm i foo@3.0.0");
   await assertFileContentsContain("foo.md", "yarn add foo@3.0.0");
 });
+
+test("prepare passes the `context` as the final function argument to `to` callbacks", async () => {
+  const replacements = [
+    {
+      files: [path.join(d.name, "/foo.md")],
+      from: /npm i (.*)@(.*)`/,
+      to: (_: string, package_name: string, ...args: unknown[]) => {
+        let reversed_package_name = package_name.split("").reverse().join("");
+        let context = args.pop() as Context;
+
+        return `npm i ${reversed_package_name}@${context?.nextRelease?.version}`;
+      },
+    },
+  ];
+
+  await prepare({ replacements }, context);
+
+  await assertFileContentsContain(
+    "foo.md",
+    `npm i oof@${context.nextRelease.version}`
+  );
+  await assertFileContentsContain("foo.md", "yarn add foo@1.0.0");
+});

--- a/__tests__/prepare.test.ts
+++ b/__tests__/prepare.test.ts
@@ -226,3 +226,22 @@ test("prepare accepts callback functions for `from`", async () => {
   await assertFileContentsContain("foo.md", "npm i foo@2.0.0");
   await assertFileContentsContain("foo.md", "yarn add foo@1.0.0");
 });
+
+test("prepare accepts multi-argument `to` callback functions for regular expression `from`", async () => {
+  const replacements = [
+    {
+      files: [path.join(d.name, "/foo.md")],
+      from: /npm i (.+)@(.+)`/g,
+      to: (match: string, package_name: string, version: string) => {
+        return match
+          .replace(version, context.nextRelease.version)
+          .replace(package_name, package_name.split("").reverse().join(""));
+      },
+    },
+  ];
+
+  await prepare({ replacements }, context);
+
+  await assertFileContentsContain("foo.md", "npm i oof@2.0.0");
+  await assertFileContentsContain("foo.md", "yarn add foo@1.0.0");
+});

--- a/__tests__/prepare.test.ts
+++ b/__tests__/prepare.test.ts
@@ -315,3 +315,33 @@ test("prepare accepts an array of `from` matchers", async () => {
   await assertFileContentsContain("foo.md", "bar `npm i bar@bar`");
   await assertFileContentsContain("foo.md", "install with `yarn add foo@bar`");
 });
+
+test("prepare accepts an array of `to` replacements", async () => {
+  // This replaces `npm i` with `npm install` and all occurrences of `1.0.0`
+  // with the `version` of the `nextRelease` as string `from` matchers are
+  // turned into global regular expressions
+  const replacements = [
+    {
+      files: [path.join(d.name, "/foo.md")],
+      from: ["npm i", "1.0.0"],
+      to: [
+        "npm install",
+        (...args: unknown[]) => {
+          const context = args.pop() as Context;
+          return context?.nextRelease?.version || "";
+        },
+      ],
+    },
+  ];
+
+  await prepare({ replacements }, context);
+
+  await assertFileContentsContain(
+    "foo.md",
+    `npm install foo@${context.nextRelease.version}`
+  );
+  await assertFileContentsContain(
+    "foo.md",
+    `yarn add foo@${context.nextRelease.version}`
+  );
+});

--- a/__tests__/prepare.test.ts
+++ b/__tests__/prepare.test.ts
@@ -292,3 +292,26 @@ test("prepare passes the `context` as the final function argument to `to` callba
   );
   await assertFileContentsContain("foo.md", "yarn add foo@1.0.0");
 });
+
+test("prepare accepts an array of `from` matchers", async () => {
+  const replacements = [
+    {
+      files: [path.join(d.name, "/foo.md")],
+      // Similarly to single string values, strings in arrays should be taken
+      // to mean global replacements for improved JSON configuration
+      // capabilities. The regular expression and function matchers should only
+      // replace a single occurrence and hence only affect the `npm` line
+      from: [
+        "1.0.0",
+        /install with/,
+        (filename: string) => path.basename(filename, ".md"),
+      ],
+      to: "bar",
+    },
+  ];
+
+  await prepare({ replacements }, context);
+
+  await assertFileContentsContain("foo.md", "bar `npm i bar@bar`");
+  await assertFileContentsContain("foo.md", "install with `yarn add foo@bar`");
+});

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -13,8 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { From } from "replace-in-file";
 import { Context } from "semantic-release";
+declare type From = FromCallback | RegExp | string;
+declare type FromCallback = (filename: string, ...args: unknown[]) => RegExp | string;
 /**
  * Replacement is simlar to the interface used by https://www.npmjs.com/package/replace-in-file
  * with the difference being the single string for `to` and `from`.
@@ -109,3 +110,4 @@ export interface PluginConfig {
     replacements: Replacement[];
 }
 export declare function prepare(PluginConfig: PluginConfig, context: Context): Promise<void>;
+export {};

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { From } from "replace-in-file";
 import { Context } from "semantic-release";
 /**
  * Replacement is simlar to the interface used by https://www.npmjs.com/package/replace-in-file
@@ -26,9 +27,16 @@ export interface Replacement {
     /**
      * The RegExp pattern to use to match.
      *
-     * Uses `String.replace(new RegExp(s, 'g'), to)` for implementation.
+     * Uses `String.replace(new RegExp(s, 'gm'), to)` for implementation, if
+     * `from` is a string.
+     *
+     * For advanced matching, i.e. when using a `release.config.js` file, consult
+     * the documentation of the `replace-in-file` package
+     * (https://github.com/adamreisnz/replace-in-file/blob/main/README.md) on its
+     * `from` option. This allows explicit specification of `RegExp`s, callback
+     * functions, etc.
      */
-    from: string;
+    from: From;
     /**
      * The replacement value using a template of variables.
      *

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -37,7 +37,7 @@ export interface Replacement {
      * The context object is used to render the template. Additional values
      * can be found at: https://semantic-release.gitbook.io/semantic-release/developer-guide/js-api#result
      *
-     * For advacned replacement, pass in a function to replace non-standard variables
+     * For advanced replacement (NOTE: only for use with `release.config.js` file version), pass in a function to replace non-standard variables
      * ```
      * {
      *    from: `__VERSION__ = 11`, // eslint-disable-line

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -16,6 +16,8 @@
 import { Context } from "semantic-release";
 declare type From = FromCallback | RegExp | string;
 declare type FromCallback = (filename: string, ...args: unknown[]) => RegExp | string;
+declare type To = string | ToCallback;
+declare type ToCallback = (match: string, ...args: unknown[]) => string;
 /**
  * Replacement is simlar to the interface used by https://www.npmjs.com/package/replace-in-file
  * with the difference being the single string for `to` and `from`.
@@ -62,8 +64,12 @@ export interface Replacement {
      * replacement is done. If `from` is a regular expression the `args` of the
      * callback include captures, the offset of the matched string, the matched
      * string, etc. See the `String.replace` documentation for details
+     *
+     * Multiple replacements may be specified as an array. These can be either
+     * strings or callback functions. Note that the amount of replacements needs
+     * to match the amount of `from` matchers.
      */
-    to: string | ((match: string, ...args: unknown[]) => string);
+    to: To | To[];
     ignore?: string[];
     allowEmptyPaths?: boolean;
     countMatches?: boolean;

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -36,8 +36,11 @@ export interface Replacement {
      * (https://github.com/adamreisnz/replace-in-file/blob/main/README.md) on its
      * `from` option. This allows explicit specification of `RegExp`s, callback
      * functions, etc.
+     *
+     * Multiple matchers may be provided as an array, following the same
+     * conversion rules as mentioned above.
      */
-    from: From;
+    from: From | From[];
     /**
      * The replacement value using a template of variables.
      *

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -52,8 +52,14 @@ export interface Replacement {
      *    to: (matched) => `__VERSION: ${parseInt(matched.split('=')[1].trim()) + 1}`, // eslint-disable-line
      *  },
      * ```
+     *
+     * The `args` for a callback function can take a variety of shapes. In its
+     * simplest form, e.g. if `from` is a string, it's the filename in which the
+     * replacement is done. If `from` is a regular expression the `args` of the
+     * callback include captures, the offset of the matched string, the matched
+     * string, etc. See the `String.replace` documentation for details
      */
-    to: string | ((a: string) => string);
+    to: string | ((match: string, ...args: unknown[]) => string);
     ignore?: string[];
     allowEmptyPaths?: boolean;
     countMatches?: boolean;

--- a/dist/index.js
+++ b/dist/index.js
@@ -87,7 +87,15 @@ function prepare(PluginConfig, context) {
                         typeof replacement.to === "function"
                             ? replacement.to
                             : lodash_1.template(replacement.to)(__assign({}, context));
-                    replaceInFileConfig.from = new RegExp(replacement.from, "gm");
+                    // The `replace-in-file` package uses `String.replace` under the hood for
+                    // the actual replacement. If `from` is a string, this means only a
+                    // single occurence will be replaced. This plugin intents to replace
+                    // _all_ occurrences when given a string to better support
+                    // configuration through JSON, this requires conversion into a `RegExp`
+                    replaceInFileConfig.from =
+                        typeof replacement.from === "string"
+                            ? new RegExp(replacement.from, "gm")
+                            : replacement.from;
                     return [4 /*yield*/, replace_in_file_1.replaceInFile(replaceInFileConfig)];
                 case 2:
                     actual = _b.sent();

--- a/dist/index.js
+++ b/dist/index.js
@@ -96,10 +96,6 @@ function prepare(PluginConfig, context) {
                     results = replacement.results;
                     delete replacement.results;
                     replaceInFileConfig = replacement;
-                    replaceInFileConfig.to =
-                        typeof replacement.to === "function"
-                            ? replacement.to
-                            : lodash_1.template(replacement.to)(__assign({}, context));
                     // The `replace-in-file` package uses `String.replace` under the hood for
                     // the actual replacement. If `from` is a string, this means only a
                     // single occurence will be replaced. This plugin intents to replace
@@ -115,6 +111,10 @@ function prepare(PluginConfig, context) {
                     else if (typeof replacement.from === "function") {
                         replaceInFileConfig.from = applyContextTo(replacement.from, context);
                     }
+                    replaceInFileConfig.to =
+                        typeof replacement.to === "function"
+                            ? applyContextTo(replacement.to, context)
+                            : lodash_1.template(replacement.to)(__assign({}, context));
                     return [4 /*yield*/, replace_in_file_1.replaceInFile(replaceInFileConfig)];
                 case 2:
                     actual = _b.sent();

--- a/docs/interfaces/_index_.pluginconfig.md
+++ b/docs/interfaces/_index_.pluginconfig.md
@@ -46,6 +46,6 @@ PluginConfig is used to provide multiple replacement.
 
 •  **replacements**: [Replacement](_index_.replacement.md)[]
 
-*Defined in [index.ts:101](https://github.com/google/semantic-release-replace-plugin/blob/master/src/index.ts#L101)*
+*Defined in [index.ts:101](https://github.com/google/semantic-release-replace-plugin/blob/70b91ae/src/index.ts#L101)*
 
 An array of replacements to be made.

--- a/docs/interfaces/_index_.pluginconfig.md
+++ b/docs/interfaces/_index_.pluginconfig.md
@@ -46,6 +46,6 @@ PluginConfig is used to provide multiple replacement.
 
 •  **replacements**: [Replacement](_index_.replacement.md)[]
 
-*Defined in [index.ts:122](https://github.com/google/semantic-release-replace-plugin/blob/997c65a/src/index.ts#L122)*
+*Defined in [index.ts:128](https://github.com/google/semantic-release-replace-plugin/blob/60c4ca8/src/index.ts#L128)*
 
 An array of replacements to be made.

--- a/docs/interfaces/_index_.pluginconfig.md
+++ b/docs/interfaces/_index_.pluginconfig.md
@@ -46,6 +46,6 @@ PluginConfig is used to provide multiple replacement.
 
 •  **replacements**: [Replacement](_index_.replacement.md)[]
 
-*Defined in [index.ts:119](https://github.com/google/semantic-release-replace-plugin/blob/1cdf9e4/src/index.ts#L119)*
+*Defined in [index.ts:122](https://github.com/google/semantic-release-replace-plugin/blob/997c65a/src/index.ts#L122)*
 
 An array of replacements to be made.

--- a/docs/interfaces/_index_.pluginconfig.md
+++ b/docs/interfaces/_index_.pluginconfig.md
@@ -46,6 +46,6 @@ PluginConfig is used to provide multiple replacement.
 
 •  **replacements**: [Replacement](_index_.replacement.md)[]
 
-*Defined in [index.ts:101](https://github.com/google/semantic-release-replace-plugin/blob/70b91ae/src/index.ts#L101)*
+*Defined in [index.ts:108](https://github.com/google/semantic-release-replace-plugin/blob/eefac95/src/index.ts#L108)*
 
 An array of replacements to be made.

--- a/docs/interfaces/_index_.pluginconfig.md
+++ b/docs/interfaces/_index_.pluginconfig.md
@@ -46,6 +46,6 @@ PluginConfig is used to provide multiple replacement.
 
 •  **replacements**: [Replacement](_index_.replacement.md)[]
 
-*Defined in [index.ts:114](https://github.com/google/semantic-release-replace-plugin/blob/f8aec3c/src/index.ts#L114)*
+*Defined in [index.ts:119](https://github.com/google/semantic-release-replace-plugin/blob/1cdf9e4/src/index.ts#L119)*
 
 An array of replacements to be made.

--- a/docs/interfaces/_index_.pluginconfig.md
+++ b/docs/interfaces/_index_.pluginconfig.md
@@ -46,6 +46,6 @@ PluginConfig is used to provide multiple replacement.
 
 •  **replacements**: [Replacement](_index_.replacement.md)[]
 
-*Defined in [index.ts:108](https://github.com/google/semantic-release-replace-plugin/blob/eefac95/src/index.ts#L108)*
+*Defined in [index.ts:114](https://github.com/google/semantic-release-replace-plugin/blob/f8aec3c/src/index.ts#L114)*
 
 An array of replacements to be made.

--- a/docs/interfaces/_index_.replacement.md
+++ b/docs/interfaces/_index_.replacement.md
@@ -32,7 +32,7 @@ with the difference being the single string for `to` and `from`.
 
 • `Optional` **allowEmptyPaths**: boolean
 
-*Defined in [index.ts:77](https://github.com/google/semantic-release-replace-plugin/blob/997c65a/src/index.ts#L77)*
+*Defined in [index.ts:83](https://github.com/google/semantic-release-replace-plugin/blob/60c4ca8/src/index.ts#L83)*
 
 ___
 
@@ -40,7 +40,7 @@ ___
 
 • `Optional` **countMatches**: boolean
 
-*Defined in [index.ts:78](https://github.com/google/semantic-release-replace-plugin/blob/997c65a/src/index.ts#L78)*
+*Defined in [index.ts:84](https://github.com/google/semantic-release-replace-plugin/blob/60c4ca8/src/index.ts#L84)*
 
 ___
 
@@ -48,7 +48,7 @@ ___
 
 • `Optional` **disableGlobs**: boolean
 
-*Defined in [index.ts:79](https://github.com/google/semantic-release-replace-plugin/blob/997c65a/src/index.ts#L79)*
+*Defined in [index.ts:85](https://github.com/google/semantic-release-replace-plugin/blob/60c4ca8/src/index.ts#L85)*
 
 ___
 
@@ -56,7 +56,7 @@ ___
 
 • `Optional` **dry**: boolean
 
-*Defined in [index.ts:81](https://github.com/google/semantic-release-replace-plugin/blob/997c65a/src/index.ts#L81)*
+*Defined in [index.ts:87](https://github.com/google/semantic-release-replace-plugin/blob/60c4ca8/src/index.ts#L87)*
 
 ___
 
@@ -64,7 +64,7 @@ ___
 
 • `Optional` **encoding**: string
 
-*Defined in [index.ts:80](https://github.com/google/semantic-release-replace-plugin/blob/997c65a/src/index.ts#L80)*
+*Defined in [index.ts:86](https://github.com/google/semantic-release-replace-plugin/blob/60c4ca8/src/index.ts#L86)*
 
 ___
 
@@ -72,7 +72,7 @@ ___
 
 •  **files**: string[]
 
-*Defined in [index.ts:36](https://github.com/google/semantic-release-replace-plugin/blob/1cdf9e4/src/index.ts#L36)*
+*Defined in [index.ts:38](https://github.com/google/semantic-release-replace-plugin/blob/60c4ca8/src/index.ts#L38)*
 
 files to search for replacements
 
@@ -82,7 +82,7 @@ ___
 
 •  **from**: From \| From[]
 
-*Defined in [index.ts:52](https://github.com/google/semantic-release-replace-plugin/blob/997c65a/src/index.ts#L52)*
+*Defined in [index.ts:54](https://github.com/google/semantic-release-replace-plugin/blob/60c4ca8/src/index.ts#L54)*
 
 The RegExp pattern to use to match.
 
@@ -104,7 +104,7 @@ ___
 
 • `Optional` **ignore**: string[]
 
-*Defined in [index.ts:76](https://github.com/google/semantic-release-replace-plugin/blob/997c65a/src/index.ts#L76)*
+*Defined in [index.ts:82](https://github.com/google/semantic-release-replace-plugin/blob/60c4ca8/src/index.ts#L82)*
 
 ___
 
@@ -112,7 +112,7 @@ ___
 
 • `Optional` **results**: { file: string ; hasChanged: boolean ; numMatches?: number ; numReplacements?: number  }[]
 
-*Defined in [index.ts:86](https://github.com/google/semantic-release-replace-plugin/blob/997c65a/src/index.ts#L86)*
+*Defined in [index.ts:92](https://github.com/google/semantic-release-replace-plugin/blob/60c4ca8/src/index.ts#L92)*
 
 The results array can be passed to ensure that the expected replacements
 have been made, and if not, throw and exception with the diff.
@@ -121,9 +121,9 @@ ___
 
 ### to
 
-•  **to**: string \| (match: string, ...args: unknown[]) => string
+•  **to**: To \| To[]
 
-*Defined in [index.ts:75](https://github.com/google/semantic-release-replace-plugin/blob/997c65a/src/index.ts#L75)*
+*Defined in [index.ts:81](https://github.com/google/semantic-release-replace-plugin/blob/60c4ca8/src/index.ts#L81)*
 
 The replacement value using a template of variables.
 
@@ -145,3 +145,7 @@ simplest form, e.g. if `from` is a string, it's the filename in which the
 replacement is done. If `from` is a regular expression the `args` of the
 callback include captures, the offset of the matched string, the matched
 string, etc. See the `String.replace` documentation for details
+
+Multiple replacements may be specified as an array. These can be either
+strings or callback functions. Note that the amount of replacements needs
+to match the amount of `from` matchers.

--- a/docs/interfaces/_index_.replacement.md
+++ b/docs/interfaces/_index_.replacement.md
@@ -32,7 +32,7 @@ with the difference being the single string for `to` and `from`.
 
 • `Optional` **allowEmptyPaths**: boolean
 
-*Defined in [index.ts:74](https://github.com/google/semantic-release-replace-plugin/blob/1cdf9e4/src/index.ts#L74)*
+*Defined in [index.ts:77](https://github.com/google/semantic-release-replace-plugin/blob/997c65a/src/index.ts#L77)*
 
 ___
 
@@ -40,7 +40,7 @@ ___
 
 • `Optional` **countMatches**: boolean
 
-*Defined in [index.ts:75](https://github.com/google/semantic-release-replace-plugin/blob/1cdf9e4/src/index.ts#L75)*
+*Defined in [index.ts:78](https://github.com/google/semantic-release-replace-plugin/blob/997c65a/src/index.ts#L78)*
 
 ___
 
@@ -48,7 +48,7 @@ ___
 
 • `Optional` **disableGlobs**: boolean
 
-*Defined in [index.ts:76](https://github.com/google/semantic-release-replace-plugin/blob/1cdf9e4/src/index.ts#L76)*
+*Defined in [index.ts:79](https://github.com/google/semantic-release-replace-plugin/blob/997c65a/src/index.ts#L79)*
 
 ___
 
@@ -56,7 +56,7 @@ ___
 
 • `Optional` **dry**: boolean
 
-*Defined in [index.ts:78](https://github.com/google/semantic-release-replace-plugin/blob/1cdf9e4/src/index.ts#L78)*
+*Defined in [index.ts:81](https://github.com/google/semantic-release-replace-plugin/blob/997c65a/src/index.ts#L81)*
 
 ___
 
@@ -64,7 +64,7 @@ ___
 
 • `Optional` **encoding**: string
 
-*Defined in [index.ts:77](https://github.com/google/semantic-release-replace-plugin/blob/1cdf9e4/src/index.ts#L77)*
+*Defined in [index.ts:80](https://github.com/google/semantic-release-replace-plugin/blob/997c65a/src/index.ts#L80)*
 
 ___
 
@@ -80,9 +80,9 @@ ___
 
 ### from
 
-•  **from**: From
+•  **from**: From \| From[]
 
-*Defined in [index.ts:49](https://github.com/google/semantic-release-replace-plugin/blob/1cdf9e4/src/index.ts#L49)*
+*Defined in [index.ts:52](https://github.com/google/semantic-release-replace-plugin/blob/997c65a/src/index.ts#L52)*
 
 The RegExp pattern to use to match.
 
@@ -95,13 +95,16 @@ the documentation of the `replace-in-file` package
 `from` option. This allows explicit specification of `RegExp`s, callback
 functions, etc.
 
+Multiple matchers may be provided as an array, following the same
+conversion rules as mentioned above.
+
 ___
 
 ### ignore
 
 • `Optional` **ignore**: string[]
 
-*Defined in [index.ts:73](https://github.com/google/semantic-release-replace-plugin/blob/1cdf9e4/src/index.ts#L73)*
+*Defined in [index.ts:76](https://github.com/google/semantic-release-replace-plugin/blob/997c65a/src/index.ts#L76)*
 
 ___
 
@@ -109,7 +112,7 @@ ___
 
 • `Optional` **results**: { file: string ; hasChanged: boolean ; numMatches?: number ; numReplacements?: number  }[]
 
-*Defined in [index.ts:83](https://github.com/google/semantic-release-replace-plugin/blob/1cdf9e4/src/index.ts#L83)*
+*Defined in [index.ts:86](https://github.com/google/semantic-release-replace-plugin/blob/997c65a/src/index.ts#L86)*
 
 The results array can be passed to ensure that the expected replacements
 have been made, and if not, throw and exception with the diff.
@@ -120,7 +123,7 @@ ___
 
 •  **to**: string \| (match: string, ...args: unknown[]) => string
 
-*Defined in [index.ts:72](https://github.com/google/semantic-release-replace-plugin/blob/1cdf9e4/src/index.ts#L72)*
+*Defined in [index.ts:75](https://github.com/google/semantic-release-replace-plugin/blob/997c65a/src/index.ts#L75)*
 
 The replacement value using a template of variables.
 

--- a/docs/interfaces/_index_.replacement.md
+++ b/docs/interfaces/_index_.replacement.md
@@ -32,7 +32,7 @@ with the difference being the single string for `to` and `from`.
 
 • `Optional` **allowEmptyPaths**: boolean
 
-*Defined in [index.ts:56](https://github.com/Borduhh/semantic-release-replace-plugin/blob/6dd4918/src/index.ts#L56)*
+*Defined in [index.ts:56](https://github.com/google/semantic-release-replace-plugin/blob/70b91ae/src/index.ts#L56)*
 
 ___
 
@@ -40,7 +40,7 @@ ___
 
 • `Optional` **countMatches**: boolean
 
-*Defined in [index.ts:57](https://github.com/Borduhh/semantic-release-replace-plugin/blob/6dd4918/src/index.ts#L57)*
+*Defined in [index.ts:57](https://github.com/google/semantic-release-replace-plugin/blob/70b91ae/src/index.ts#L57)*
 
 ___
 
@@ -48,7 +48,7 @@ ___
 
 • `Optional` **disableGlobs**: boolean
 
-*Defined in [index.ts:58](https://github.com/Borduhh/semantic-release-replace-plugin/blob/6dd4918/src/index.ts#L58)*
+*Defined in [index.ts:58](https://github.com/google/semantic-release-replace-plugin/blob/70b91ae/src/index.ts#L58)*
 
 ___
 
@@ -56,7 +56,7 @@ ___
 
 • `Optional` **dry**: boolean
 
-*Defined in [index.ts:60](https://github.com/Borduhh/semantic-release-replace-plugin/blob/6dd4918/src/index.ts#L60)*
+*Defined in [index.ts:60](https://github.com/google/semantic-release-replace-plugin/blob/70b91ae/src/index.ts#L60)*
 
 ___
 
@@ -64,7 +64,7 @@ ___
 
 • `Optional` **encoding**: string
 
-*Defined in [index.ts:59](https://github.com/Borduhh/semantic-release-replace-plugin/blob/6dd4918/src/index.ts#L59)*
+*Defined in [index.ts:59](https://github.com/google/semantic-release-replace-plugin/blob/70b91ae/src/index.ts#L59)*
 
 ___
 
@@ -72,7 +72,7 @@ ___
 
 •  **files**: string[]
 
-*Defined in [index.ts:31](https://github.com/Borduhh/semantic-release-replace-plugin/blob/6dd4918/src/index.ts#L31)*
+*Defined in [index.ts:31](https://github.com/google/semantic-release-replace-plugin/blob/70b91ae/src/index.ts#L31)*
 
 files to search for replacements
 
@@ -82,7 +82,7 @@ ___
 
 •  **from**: string
 
-*Defined in [index.ts:37](https://github.com/Borduhh/semantic-release-replace-plugin/blob/6dd4918/src/index.ts#L37)*
+*Defined in [index.ts:37](https://github.com/google/semantic-release-replace-plugin/blob/70b91ae/src/index.ts#L37)*
 
 The RegExp pattern to use to match.
 
@@ -94,7 +94,7 @@ ___
 
 • `Optional` **ignore**: string[]
 
-*Defined in [index.ts:55](https://github.com/Borduhh/semantic-release-replace-plugin/blob/6dd4918/src/index.ts#L55)*
+*Defined in [index.ts:55](https://github.com/google/semantic-release-replace-plugin/blob/70b91ae/src/index.ts#L55)*
 
 ___
 
@@ -102,7 +102,7 @@ ___
 
 • `Optional` **results**: { file: string ; hasChanged: boolean ; numMatches?: number ; numReplacements?: number  }[]
 
-*Defined in [index.ts:65](https://github.com/Borduhh/semantic-release-replace-plugin/blob/6dd4918/src/index.ts#L65)*
+*Defined in [index.ts:65](https://github.com/google/semantic-release-replace-plugin/blob/70b91ae/src/index.ts#L65)*
 
 The results array can be passed to ensure that the expected replacements
 have been made, and if not, throw and exception with the diff.
@@ -113,7 +113,7 @@ ___
 
 •  **to**: string \| (a: string) => string
 
-*Defined in [index.ts:54](https://github.com/Borduhh/semantic-release-replace-plugin/blob/6dd4918/src/index.ts#L54)*
+*Defined in [index.ts:54](https://github.com/google/semantic-release-replace-plugin/blob/70b91ae/src/index.ts#L54)*
 
 The replacement value using a template of variables.
 
@@ -122,7 +122,7 @@ The replacement value using a template of variables.
 The context object is used to render the template. Additional values
 can be found at: https://semantic-release.gitbook.io/semantic-release/developer-guide/js-api#result
 
-For advacned replacement, pass in a function to replace non-standard variables
+For advanced replacement (NOTE: only for use with `release.config.js` file version), pass in a function to replace non-standard variables
 ```
 {
    from: `__VERSION__ = 11`, // eslint-disable-line

--- a/docs/interfaces/_index_.replacement.md
+++ b/docs/interfaces/_index_.replacement.md
@@ -32,7 +32,7 @@ with the difference being the single string for `to` and `from`.
 
 • `Optional` **allowEmptyPaths**: boolean
 
-*Defined in [index.ts:69](https://github.com/google/semantic-release-replace-plugin/blob/f8aec3c/src/index.ts#L69)*
+*Defined in [index.ts:74](https://github.com/google/semantic-release-replace-plugin/blob/1cdf9e4/src/index.ts#L74)*
 
 ___
 
@@ -40,7 +40,7 @@ ___
 
 • `Optional` **countMatches**: boolean
 
-*Defined in [index.ts:70](https://github.com/google/semantic-release-replace-plugin/blob/f8aec3c/src/index.ts#L70)*
+*Defined in [index.ts:75](https://github.com/google/semantic-release-replace-plugin/blob/1cdf9e4/src/index.ts#L75)*
 
 ___
 
@@ -48,7 +48,7 @@ ___
 
 • `Optional` **disableGlobs**: boolean
 
-*Defined in [index.ts:71](https://github.com/google/semantic-release-replace-plugin/blob/f8aec3c/src/index.ts#L71)*
+*Defined in [index.ts:76](https://github.com/google/semantic-release-replace-plugin/blob/1cdf9e4/src/index.ts#L76)*
 
 ___
 
@@ -56,7 +56,7 @@ ___
 
 • `Optional` **dry**: boolean
 
-*Defined in [index.ts:73](https://github.com/google/semantic-release-replace-plugin/blob/f8aec3c/src/index.ts#L73)*
+*Defined in [index.ts:78](https://github.com/google/semantic-release-replace-plugin/blob/1cdf9e4/src/index.ts#L78)*
 
 ___
 
@@ -64,7 +64,7 @@ ___
 
 • `Optional` **encoding**: string
 
-*Defined in [index.ts:72](https://github.com/google/semantic-release-replace-plugin/blob/f8aec3c/src/index.ts#L72)*
+*Defined in [index.ts:77](https://github.com/google/semantic-release-replace-plugin/blob/1cdf9e4/src/index.ts#L77)*
 
 ___
 
@@ -72,7 +72,7 @@ ___
 
 •  **files**: string[]
 
-*Defined in [index.ts:31](https://github.com/google/semantic-release-replace-plugin/blob/70b91ae/src/index.ts#L31)*
+*Defined in [index.ts:36](https://github.com/google/semantic-release-replace-plugin/blob/1cdf9e4/src/index.ts#L36)*
 
 files to search for replacements
 
@@ -82,7 +82,7 @@ ___
 
 •  **from**: From
 
-*Defined in [index.ts:44](https://github.com/google/semantic-release-replace-plugin/blob/eefac95/src/index.ts#L44)*
+*Defined in [index.ts:49](https://github.com/google/semantic-release-replace-plugin/blob/1cdf9e4/src/index.ts#L49)*
 
 The RegExp pattern to use to match.
 
@@ -101,7 +101,7 @@ ___
 
 • `Optional` **ignore**: string[]
 
-*Defined in [index.ts:68](https://github.com/google/semantic-release-replace-plugin/blob/f8aec3c/src/index.ts#L68)*
+*Defined in [index.ts:73](https://github.com/google/semantic-release-replace-plugin/blob/1cdf9e4/src/index.ts#L73)*
 
 ___
 
@@ -109,7 +109,7 @@ ___
 
 • `Optional` **results**: { file: string ; hasChanged: boolean ; numMatches?: number ; numReplacements?: number  }[]
 
-*Defined in [index.ts:78](https://github.com/google/semantic-release-replace-plugin/blob/f8aec3c/src/index.ts#L78)*
+*Defined in [index.ts:83](https://github.com/google/semantic-release-replace-plugin/blob/1cdf9e4/src/index.ts#L83)*
 
 The results array can be passed to ensure that the expected replacements
 have been made, and if not, throw and exception with the diff.
@@ -120,7 +120,7 @@ ___
 
 •  **to**: string \| (match: string, ...args: unknown[]) => string
 
-*Defined in [index.ts:67](https://github.com/google/semantic-release-replace-plugin/blob/f8aec3c/src/index.ts#L67)*
+*Defined in [index.ts:72](https://github.com/google/semantic-release-replace-plugin/blob/1cdf9e4/src/index.ts#L72)*
 
 The replacement value using a template of variables.
 

--- a/docs/interfaces/_index_.replacement.md
+++ b/docs/interfaces/_index_.replacement.md
@@ -32,7 +32,7 @@ with the difference being the single string for `to` and `from`.
 
 • `Optional` **allowEmptyPaths**: boolean
 
-*Defined in [index.ts:63](https://github.com/google/semantic-release-replace-plugin/blob/eefac95/src/index.ts#L63)*
+*Defined in [index.ts:69](https://github.com/google/semantic-release-replace-plugin/blob/f8aec3c/src/index.ts#L69)*
 
 ___
 
@@ -40,7 +40,7 @@ ___
 
 • `Optional` **countMatches**: boolean
 
-*Defined in [index.ts:64](https://github.com/google/semantic-release-replace-plugin/blob/eefac95/src/index.ts#L64)*
+*Defined in [index.ts:70](https://github.com/google/semantic-release-replace-plugin/blob/f8aec3c/src/index.ts#L70)*
 
 ___
 
@@ -48,7 +48,7 @@ ___
 
 • `Optional` **disableGlobs**: boolean
 
-*Defined in [index.ts:65](https://github.com/google/semantic-release-replace-plugin/blob/eefac95/src/index.ts#L65)*
+*Defined in [index.ts:71](https://github.com/google/semantic-release-replace-plugin/blob/f8aec3c/src/index.ts#L71)*
 
 ___
 
@@ -56,7 +56,7 @@ ___
 
 • `Optional` **dry**: boolean
 
-*Defined in [index.ts:67](https://github.com/google/semantic-release-replace-plugin/blob/eefac95/src/index.ts#L67)*
+*Defined in [index.ts:73](https://github.com/google/semantic-release-replace-plugin/blob/f8aec3c/src/index.ts#L73)*
 
 ___
 
@@ -64,7 +64,7 @@ ___
 
 • `Optional` **encoding**: string
 
-*Defined in [index.ts:66](https://github.com/google/semantic-release-replace-plugin/blob/eefac95/src/index.ts#L66)*
+*Defined in [index.ts:72](https://github.com/google/semantic-release-replace-plugin/blob/f8aec3c/src/index.ts#L72)*
 
 ___
 
@@ -101,7 +101,7 @@ ___
 
 • `Optional` **ignore**: string[]
 
-*Defined in [index.ts:62](https://github.com/google/semantic-release-replace-plugin/blob/eefac95/src/index.ts#L62)*
+*Defined in [index.ts:68](https://github.com/google/semantic-release-replace-plugin/blob/f8aec3c/src/index.ts#L68)*
 
 ___
 
@@ -109,7 +109,7 @@ ___
 
 • `Optional` **results**: { file: string ; hasChanged: boolean ; numMatches?: number ; numReplacements?: number  }[]
 
-*Defined in [index.ts:72](https://github.com/google/semantic-release-replace-plugin/blob/eefac95/src/index.ts#L72)*
+*Defined in [index.ts:78](https://github.com/google/semantic-release-replace-plugin/blob/f8aec3c/src/index.ts#L78)*
 
 The results array can be passed to ensure that the expected replacements
 have been made, and if not, throw and exception with the diff.
@@ -118,9 +118,9 @@ ___
 
 ### to
 
-•  **to**: string \| (a: string) => string
+•  **to**: string \| (match: string, ...args: unknown[]) => string
 
-*Defined in [index.ts:61](https://github.com/google/semantic-release-replace-plugin/blob/eefac95/src/index.ts#L61)*
+*Defined in [index.ts:67](https://github.com/google/semantic-release-replace-plugin/blob/f8aec3c/src/index.ts#L67)*
 
 The replacement value using a template of variables.
 
@@ -136,3 +136,9 @@ For advanced replacement (NOTE: only for use with `release.config.js` file versi
    to: (matched) => `__VERSION: ${parseInt(matched.split('=')[1].trim()) + 1}`, // eslint-disable-line
  },
 ```
+
+The `args` for a callback function can take a variety of shapes. In its
+simplest form, e.g. if `from` is a string, it's the filename in which the
+replacement is done. If `from` is a regular expression the `args` of the
+callback include captures, the offset of the matched string, the matched
+string, etc. See the `String.replace` documentation for details

--- a/docs/interfaces/_index_.replacement.md
+++ b/docs/interfaces/_index_.replacement.md
@@ -32,7 +32,7 @@ with the difference being the single string for `to` and `from`.
 
 • `Optional` **allowEmptyPaths**: boolean
 
-*Defined in [index.ts:56](https://github.com/google/semantic-release-replace-plugin/blob/70b91ae/src/index.ts#L56)*
+*Defined in [index.ts:63](https://github.com/google/semantic-release-replace-plugin/blob/eefac95/src/index.ts#L63)*
 
 ___
 
@@ -40,7 +40,7 @@ ___
 
 • `Optional` **countMatches**: boolean
 
-*Defined in [index.ts:57](https://github.com/google/semantic-release-replace-plugin/blob/70b91ae/src/index.ts#L57)*
+*Defined in [index.ts:64](https://github.com/google/semantic-release-replace-plugin/blob/eefac95/src/index.ts#L64)*
 
 ___
 
@@ -48,7 +48,7 @@ ___
 
 • `Optional` **disableGlobs**: boolean
 
-*Defined in [index.ts:58](https://github.com/google/semantic-release-replace-plugin/blob/70b91ae/src/index.ts#L58)*
+*Defined in [index.ts:65](https://github.com/google/semantic-release-replace-plugin/blob/eefac95/src/index.ts#L65)*
 
 ___
 
@@ -56,7 +56,7 @@ ___
 
 • `Optional` **dry**: boolean
 
-*Defined in [index.ts:60](https://github.com/google/semantic-release-replace-plugin/blob/70b91ae/src/index.ts#L60)*
+*Defined in [index.ts:67](https://github.com/google/semantic-release-replace-plugin/blob/eefac95/src/index.ts#L67)*
 
 ___
 
@@ -64,7 +64,7 @@ ___
 
 • `Optional` **encoding**: string
 
-*Defined in [index.ts:59](https://github.com/google/semantic-release-replace-plugin/blob/70b91ae/src/index.ts#L59)*
+*Defined in [index.ts:66](https://github.com/google/semantic-release-replace-plugin/blob/eefac95/src/index.ts#L66)*
 
 ___
 
@@ -80,13 +80,20 @@ ___
 
 ### from
 
-•  **from**: string
+•  **from**: From
 
-*Defined in [index.ts:37](https://github.com/google/semantic-release-replace-plugin/blob/70b91ae/src/index.ts#L37)*
+*Defined in [index.ts:44](https://github.com/google/semantic-release-replace-plugin/blob/eefac95/src/index.ts#L44)*
 
 The RegExp pattern to use to match.
 
-Uses `String.replace(new RegExp(s, 'g'), to)` for implementation.
+Uses `String.replace(new RegExp(s, 'gm'), to)` for implementation, if
+`from` is a string.
+
+For advanced matching, i.e. when using a `release.config.js` file, consult
+the documentation of the `replace-in-file` package
+(https://github.com/adamreisnz/replace-in-file/blob/main/README.md) on its
+`from` option. This allows explicit specification of `RegExp`s, callback
+functions, etc.
 
 ___
 
@@ -94,7 +101,7 @@ ___
 
 • `Optional` **ignore**: string[]
 
-*Defined in [index.ts:55](https://github.com/google/semantic-release-replace-plugin/blob/70b91ae/src/index.ts#L55)*
+*Defined in [index.ts:62](https://github.com/google/semantic-release-replace-plugin/blob/eefac95/src/index.ts#L62)*
 
 ___
 
@@ -102,7 +109,7 @@ ___
 
 • `Optional` **results**: { file: string ; hasChanged: boolean ; numMatches?: number ; numReplacements?: number  }[]
 
-*Defined in [index.ts:65](https://github.com/google/semantic-release-replace-plugin/blob/70b91ae/src/index.ts#L65)*
+*Defined in [index.ts:72](https://github.com/google/semantic-release-replace-plugin/blob/eefac95/src/index.ts#L72)*
 
 The results array can be passed to ensure that the expected replacements
 have been made, and if not, throw and exception with the diff.
@@ -113,7 +120,7 @@ ___
 
 •  **to**: string \| (a: string) => string
 
-*Defined in [index.ts:54](https://github.com/google/semantic-release-replace-plugin/blob/70b91ae/src/index.ts#L54)*
+*Defined in [index.ts:61](https://github.com/google/semantic-release-replace-plugin/blob/eefac95/src/index.ts#L61)*
 
 The replacement value using a template of variables.
 

--- a/docs/modules/_index_.md
+++ b/docs/modules/_index_.md
@@ -21,7 +21,7 @@
 
 ▸ **prepare**(`PluginConfig`: [PluginConfig](../interfaces/_index_.pluginconfig.md), `context`: Context): Promise<void\>
 
-*Defined in [index.ts:111](https://github.com/google/semantic-release-replace-plugin/blob/eefac95/src/index.ts#L111)*
+*Defined in [index.ts:117](https://github.com/google/semantic-release-replace-plugin/blob/f8aec3c/src/index.ts#L117)*
 
 #### Parameters:
 

--- a/docs/modules/_index_.md
+++ b/docs/modules/_index_.md
@@ -21,7 +21,7 @@
 
 ▸ **prepare**(`PluginConfig`: [PluginConfig](../interfaces/_index_.pluginconfig.md), `context`: Context): Promise<void\>
 
-*Defined in [index.ts:104](https://github.com/Borduhh/semantic-release-replace-plugin/blob/6dd4918/src/index.ts#L104)*
+*Defined in [index.ts:104](https://github.com/google/semantic-release-replace-plugin/blob/70b91ae/src/index.ts#L104)*
 
 #### Parameters:
 

--- a/docs/modules/_index_.md
+++ b/docs/modules/_index_.md
@@ -21,7 +21,7 @@
 
 ▸ **prepare**(`PluginConfig`: [PluginConfig](../interfaces/_index_.pluginconfig.md), `context`: Context): Promise<void\>
 
-*Defined in [index.ts:130](https://github.com/google/semantic-release-replace-plugin/blob/1cdf9e4/src/index.ts#L130)*
+*Defined in [index.ts:141](https://github.com/google/semantic-release-replace-plugin/blob/997c65a/src/index.ts#L141)*
 
 #### Parameters:
 

--- a/docs/modules/_index_.md
+++ b/docs/modules/_index_.md
@@ -21,7 +21,7 @@
 
 ▸ **prepare**(`PluginConfig`: [PluginConfig](../interfaces/_index_.pluginconfig.md), `context`: Context): Promise<void\>
 
-*Defined in [index.ts:104](https://github.com/google/semantic-release-replace-plugin/blob/70b91ae/src/index.ts#L104)*
+*Defined in [index.ts:111](https://github.com/google/semantic-release-replace-plugin/blob/eefac95/src/index.ts#L111)*
 
 #### Parameters:
 

--- a/docs/modules/_index_.md
+++ b/docs/modules/_index_.md
@@ -21,7 +21,7 @@
 
 ▸ **prepare**(`PluginConfig`: [PluginConfig](../interfaces/_index_.pluginconfig.md), `context`: Context): Promise<void\>
 
-*Defined in [index.ts:117](https://github.com/google/semantic-release-replace-plugin/blob/f8aec3c/src/index.ts#L117)*
+*Defined in [index.ts:130](https://github.com/google/semantic-release-replace-plugin/blob/1cdf9e4/src/index.ts#L130)*
 
 #### Parameters:
 

--- a/docs/modules/_index_.md
+++ b/docs/modules/_index_.md
@@ -21,7 +21,7 @@
 
 ▸ **prepare**(`PluginConfig`: [PluginConfig](../interfaces/_index_.pluginconfig.md), `context`: Context): Promise<void\>
 
-*Defined in [index.ts:141](https://github.com/google/semantic-release-replace-plugin/blob/997c65a/src/index.ts#L141)*
+*Defined in [index.ts:157](https://github.com/google/semantic-release-replace-plugin/blob/60c4ca8/src/index.ts#L157)*
 
 #### Parameters:
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -138,11 +138,6 @@ export async function prepare(
 
     const replaceInFileConfig = replacement as ReplaceInFileConfig;
 
-    replaceInFileConfig.to =
-      typeof replacement.to === "function"
-        ? replacement.to
-        : template(replacement.to)({ ...context });
-
     // The `replace-in-file` package uses `String.replace` under the hood for
     // the actual replacement. If `from` is a string, this means only a
     // single occurence will be replaced. This plugin intents to replace
@@ -157,6 +152,11 @@ export async function prepare(
     } else if (typeof replacement.from === "function") {
       replaceInFileConfig.from = applyContextTo(replacement.from, context);
     }
+
+    replaceInFileConfig.to =
+      typeof replacement.to === "function"
+        ? applyContextTo(replacement.to, context)
+        : template(replacement.to)({ ...context });
 
     let actual = await replaceInFile(replaceInFileConfig);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { ReplaceInFileConfig, replaceInFile } from "replace-in-file";
+import { ReplaceInFileConfig, From, replaceInFile } from "replace-in-file";
 import { isEqual, template } from "lodash";
 
 import { Context } from "semantic-release";
@@ -32,9 +32,16 @@ export interface Replacement {
   /**
    * The RegExp pattern to use to match.
    *
-   * Uses `String.replace(new RegExp(s, 'g'), to)` for implementation.
+   * Uses `String.replace(new RegExp(s, 'gm'), to)` for implementation, if
+   * `from` is a string.
+   *
+   * For advanced matching, i.e. when using a `release.config.js` file, consult
+   * the documentation of the `replace-in-file` package
+   * (https://github.com/adamreisnz/replace-in-file/blob/main/README.md) on its
+   * `from` option. This allows explicit specification of `RegExp`s, callback
+   * functions, etc.
    */
-  from: string;
+  from: From;
   /**
    * The replacement value using a template of variables.
    *
@@ -116,7 +123,16 @@ export async function prepare(
       typeof replacement.to === "function"
         ? replacement.to
         : template(replacement.to)({ ...context });
-    replaceInFileConfig.from = new RegExp(replacement.from, "gm");
+
+    // The `replace-in-file` package uses `String.replace` under the hood for
+    // the actual replacement. If `from` is a string, this means only a
+    // single occurence will be replaced. This plugin intents to replace
+    // _all_ occurrences when given a string to better support
+    // configuration through JSON, this requires conversion into a `RegExp`
+    replaceInFileConfig.from =
+      typeof replacement.from === "string"
+        ? new RegExp(replacement.from, "gm")
+        : replacement.from;
 
     let actual = await replaceInFile(replaceInFileConfig);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,8 +57,14 @@ export interface Replacement {
    *    to: (matched) => `__VERSION: ${parseInt(matched.split('=')[1].trim()) + 1}`, // eslint-disable-line
    *  },
    * ```
+   *
+   * The `args` for a callback function can take a variety of shapes. In its
+   * simplest form, e.g. if `from` is a string, it's the filename in which the
+   * replacement is done. If `from` is a regular expression the `args` of the
+   * callback include captures, the offset of the matched string, the matched
+   * string, etc. See the `String.replace` documentation for details
    */
-  to: string | ((a: string) => string);
+  to: string | ((match: string, ...args: unknown[]) => string);
   ignore?: string[];
   allowEmptyPaths?: boolean;
   countMatches?: boolean;


### PR DESCRIPTION
I have some advanced use cases, such as replacing templates in documentation upon release which requires access to those templates in `from` and `to` properties, that I'd like to use this plugin for. These use cases can be enabled by making even more of the functionality of [`replace-in-file`](https://github.com/adamreisnz/replace-in-file) available through the plugin, i.e. in addition to the functionality already exposed by #156.

Specifically, these changes enable:

- [callback functions for `from`](https://github.com/adamreisnz/replace-in-file#using-callbacks-for-from).
- [regular expressions for `from`](https://github.com/adamreisnz/replace-in-file#custom-regular-expressions).
- `to` callback functions that accept multiple arguments, which is necessary to support capture groups, etc. when specifying regular expressions for `from`.
- [multiple `from` values with a single replacement](https://github.com/adamreisnz/replace-in-file#multiple-values-with-the-same-replacement).
- [multiple `from` values with different replacements](https://github.com/adamreisnz/replace-in-file#multiple-values-with-different-replacements).

These use cases also require access to the semantic release `context` in callback functions, so this also adds an alternative to #167 by passing the semantic release `context` to `from` and `to` callbacks as the final argument. This seems slightly less magical than making it available on `this`.